### PR TITLE
Disable flaky tests

### DIFF
--- a/src/app/__tests__/testButton.tsx
+++ b/src/app/__tests__/testButton.tsx
@@ -73,7 +73,7 @@ export const itShouldBeCancellable = ({
   render,
   buttonText,
 }: TestSimulationButtonOptions) => {
-  it("should be cancellable", async () => {
+  it.skip("should be cancellable", async () => {
     await render();
 
     setWorkerResponseDelay(100);


### PR DESCRIPTION
These changes disable some tests that fail to run on GitHub's CI runners sometimes. The plan is to refactor them in the future, but at the moment it is not worth dealing with them. The cause is likely race conditions with the mock workers manually dispatching events.