### PR TITLE
Switch to atomWithStorage for saving theme and font size

### DIFF
--- a/src/app/WorkspaceProvider.tsx
+++ b/src/app/WorkspaceProvider.tsx
@@ -57,8 +57,6 @@ const Initialize = ({
         }
 
         if (savedData) {
-          setThemeOption(savedData.theme);
-          setEditorFontSize(savedData.editorFontSize);
           updateAllHistory(savedData.workspace.history);
           updateAllChatHistory(savedData.workspace.chatHistory ?? []);
           setVariableSettingss(savedData.workspace.variableSettingss);

--- a/src/features/saving.ts
+++ b/src/features/saving.ts
@@ -1,7 +1,6 @@
 import type { GraphSettings, VariableSettings } from "@/globals/settings";
 import type { HistoryRecord } from "@/globals/history";
 import type { ChatConversation } from "@/globals/chat";
-import type { ThemeOption } from "@/globals/appearance";
 
 const DATABASE_NAME = "testing_database4";
 const DATABASE_VERSION = 1;
@@ -9,8 +8,6 @@ const MAIN_STORE_NAME = "main";
 const MAIN_KEY_NAME = "main";
 
 export interface SavedDataV1 {
-  theme: ThemeOption;
-  editorFontSize: number;
   workspace: {
     name: string;
     content: string;

--- a/src/globals/appearance.ts
+++ b/src/globals/appearance.ts
@@ -1,13 +1,17 @@
 import { atom } from "jotai";
 
 import { getPreferredTheme, type Theme } from "@/features/theme";
+import { atomWithStorage } from "jotai/utils";
 
 // theme
 
 export type ThemeOption = Theme | "Automatic";
 
 const _automaticThemeAtom = atom<Theme>(getPreferredTheme());
-export const themeOptionAtom = atom<ThemeOption>("Automatic");
+export const themeOptionAtom = atomWithStorage<ThemeOption>(
+  "theme",
+  "Automatic",
+);
 
 export const themeAtom = atom((get) => {
   const themeOption = get(themeOptionAtom);
@@ -29,4 +33,4 @@ export const tryUpdateThemeIfAutomaticAtom = atom(null, (_, set) => {
 });
 
 // other stuff
-export const editorFontSizeAtom = atom(12);
+export const editorFontSizeAtom = atomWithStorage("editorFontSize", 12);

--- a/src/globals/saving.ts
+++ b/src/globals/saving.ts
@@ -1,6 +1,5 @@
 import { atom } from "jotai";
 import { commitSavedData } from "@/features/saving";
-import { editorFontSizeAtom, themeOptionAtom } from "./appearance";
 import { graphSettingsAtom, nameAtom, variableSettingssAtom } from "./settings";
 import { editorContentAtom } from "./model";
 import { historyAtom } from "./history";
@@ -9,8 +8,6 @@ import { chatHistoryAtom } from "./chat";
 
 export const saveAtom = atom(null, async (get, _set): Promise<void> => {
   await commitSavedData({
-    theme: get(themeOptionAtom),
-    editorFontSize: get(editorFontSizeAtom),
     workspace: {
       name: get(nameAtom),
       graphSettings: get(graphSettingsAtom),


### PR DESCRIPTION
Jotai has a convenient function for saving your atoms: https://jotai.org/docs/utilities/storage. It also syncs across tabs.

I switched the theme and editor font size to use this.

Related to my comment in #51 