### PR TITLE
make chat prompt become default when does not exist in user saved data

### DIFF
--- a/src/app/WorkspaceProvider.tsx
+++ b/src/app/WorkspaceProvider.tsx
@@ -18,7 +18,11 @@ import {
 } from "@/globals/simulation";
 import { readShareUrlFragment } from "@/features/share";
 import { updateAllHistoryAtom } from "@/globals/history";
-import { systemPromptAtom, updateAllChatHistoryAtom } from "@/globals/chat";
+import {
+  DEFAULT_SYSTEM_PROMPT,
+  systemPromptAtom,
+  updateAllChatHistoryAtom,
+} from "@/globals/chat";
 import { apiKeyAtom } from "@/globals/chat";
 
 // simulation from share link will not be run if they use more number of points
@@ -63,7 +67,9 @@ const Initialize = ({
           setVariableSettingss(savedData.workspace.variableSettingss);
           setGraphSettings(savedData.workspace.graphSettings);
           setApiKey(savedData.workspace.apiKey ?? null);
-          setChatPrompt(savedData.workspace.chatSystemPrompt);
+          setChatPrompt(
+            savedData.workspace.chatSystemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+          );
         }
 
         const shareResult = await readShareUrlFragment(

--- a/src/features/saving.ts
+++ b/src/features/saving.ts
@@ -15,7 +15,7 @@ export interface SavedDataV1 {
     graphSettings: GraphSettings;
     history: HistoryRecord[];
     chatHistory?: ChatConversation[];
-    chatSystemPrompt: string;
+    chatSystemPrompt?: string | null;
     apiKey?: string | null;
   };
 }


### PR DESCRIPTION
Quick fix so users have the default chat prompt loaded when newly loading into the newest version of WebIridium