### PR TITLE
Mock localStorage

### DIFF
--- a/src/globals/graphPresets.ts
+++ b/src/globals/graphPresets.ts
@@ -185,22 +185,10 @@ const readStringToPresets = (str: string): Record<string, GraphSettings> => {
   return migrated;
 };
 
-// We need this because since localStorage is not available in the test env.
-const isLocalStorageAvailable = (): boolean => {
-  return (
-    typeof localStorage !== "undefined" &&
-    typeof localStorage.getItem !== "undefined"
-  );
-};
-
 const graphPresetStorage: SyncStorage<
   Record<string, GraphSettings | undefined>
 > = {
   getItem(key, initialValue) {
-    if (!isLocalStorageAvailable()) {
-      return initialValue;
-    }
-
     const got = localStorage.getItem(key);
     if (!got) {
       return initialValue;
@@ -210,25 +198,14 @@ const graphPresetStorage: SyncStorage<
   },
 
   setItem(key, value) {
-    if (!isLocalStorageAvailable()) {
-      return;
-    }
-
     localStorage.setItem(key, JSON.stringify(value));
   },
 
   removeItem(key) {
-    if (!isLocalStorageAvailable()) {
-      return;
-    }
-
     localStorage.removeItem(key);
   },
 
   subscribe(key, callback, initialValue) {
-    if (!isLocalStorageAvailable()) {
-      return;
-    }
     if (
       typeof window === "undefined" ||
       typeof window.addEventListener === "undefined"

--- a/src/vitestSetup.ts
+++ b/src/vitestSetup.ts
@@ -54,6 +54,7 @@ window.HTMLElement.prototype.scrollIntoView = vi.fn();
 window.HTMLElement.prototype.releasePointerCapture = vi.fn();
 window.HTMLElement.prototype.hasPointerCapture = vi.fn();
 
+// Mocks for media query stuff (used for theme detection).
 class MockMediaQueryList extends EventTarget {
   get matches() {
     return true;
@@ -63,3 +64,41 @@ class MockMediaQueryList extends EventTarget {
 window.matchMedia = vi.fn((_) => {
   return new MockMediaQueryList() as MediaQueryList;
 });
+
+// Mock localStorage.
+// This is because newer node versions seem to change localStorage such that our
+// older tests are failing. This mocks localStorage in memory manually
+// so that we have full control.
+const mockLocalStorage = {
+  storage: new Map<string, string>(),
+
+  clear(): void {
+    this.storage.clear();
+  },
+
+  getItem(key: string): string | null {
+    return this.storage.get(key) ?? null;
+  },
+
+  removeItem(key: string) {
+    this.storage.delete(key);
+  },
+
+  setItem(key: string, value: string) {
+    this.storage.set(key, value);
+  },
+
+  key(index: number): string | null {
+    const iterator = this.storage.keys();
+    for (let i = 0; i < index; i++) {
+      iterator.next();
+    }
+    return iterator.next().value ?? null;
+  },
+
+  get length(): number {
+    return this.storage.size;
+  },
+};
+
+window.localStorage = mockLocalStorage;


### PR DESCRIPTION
Some of the tests are failing in newer versions of Node.js because they changed something about how they handle the Web Storage API. I added a mock for localStorage to fix this.

This solution is a little brittle, but it's the most straightforward one that I could come up with.

Here is what was failing on node v25.2.1
```
 FAIL  src/app/__tests__/ChatPanel.test.tsx > ChatPanel > should display a verbose error message when API returns 401
 FAIL  src/app/__tests__/ChatPanel.test.tsx > ChatPanel > should display a verbose error message when API returns 429
 FAIL  src/app/__tests__/ChatPanel.test.tsx > ChatPanel > should display generic error for unknown errors
 FAIL  src/app/__tests__/ChatPanel.test.tsx > ChatPanel > should render LaTeX as MathML with correct attributes
TypeError: localStorage.clear is not a function
 ❯ src/app/__tests__/ChatPanel.test.tsx:13:18
     11|   beforeEach(() => {
     12|     vi.clearAllMocks();
     13|     localStorage.clear();
       |                  ^
     14|   });
     15|
```